### PR TITLE
feat: 서버 시작 시 지원 센터 데이터 가져오기 기능 추가

### DIFF
--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -36,6 +36,17 @@ dependencies {
 	//implementation 'org.apache.commons:commons-fileupload:1.4'
 	implementation 'org.json:json:20230618'
 
+
+	// Hugging Face Transformers 의존성
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	//implementation 'org.slf4j:slf4j-api:1.7.30'
+	implementation 'org.json:json:20210307'
+
+	//@PostConstruct 애노테이션을 사용
+	implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -45,6 +56,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 }
+
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
@@ -8,6 +8,7 @@ import org.springframework.web.client.RestTemplate;
 import pelican.co_labor.domain.support_center.SupportCenter;
 import pelican.co_labor.repository.support_center.SupportCenterRepository;
 
+import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +30,14 @@ public class SupportCenterService {
         this.naverGeocodingService = naverGeocodingService;
     }
 
+    @PostConstruct
+    public void init() {
+        fetchDataFromApi();
+    }
+
     public void fetchDataFromApi() {
+        supportCenterRepository.deleteAll(); // 기존 데이터 삭제
+
         // 인코딩된 키로 데이터 가져오기 시도
         try {
             fetchDataUsingKey(apiKeyEncoded);


### PR DESCRIPTION
- 서버 시작 시 자동으로 API 데이터를 가져오기 위해 @PostConstruct 구현
- 중복을 방지하기 위해 새로운 데이터를 삽입하기 전에 기존 지원 센터 데이터를 삭제
- SupportCenterService에 데이터 정리 및 가져오기 로직 업데이트

