### PR TITLE
feat: 공공 병원 데이터 API를 가져와 저장하는 기능 추가

### DIFF
--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	//@PostConstruct 애노테이션을 사용
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
+	//병원 관련 Jackson 라이브러리
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.1'
 
 
 	compileOnly 'org.projectlombok:lombok'

--- a/co-labor/src/main/java/pelican/co_labor/controller/HospitalController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/HospitalController.java
@@ -1,0 +1,27 @@
+package pelican.co_labor.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pelican.co_labor.domain.hospital.Hospital;
+import pelican.co_labor.service.HospitalService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hospitals")
+public class HospitalController {
+
+    private final HospitalService hospitalService;
+
+    @Autowired
+    public HospitalController(HospitalService hospitalService) {
+        this.hospitalService = hospitalService;
+    }
+
+    @GetMapping("/all")
+    public List<Hospital> getAllHospitals() {
+        return hospitalService.getAllHospitals();
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
@@ -1,0 +1,33 @@
+package pelican.co_labor.domain.hospital;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "hospital")
+public class Hospital {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String dutyAddr;
+
+    @Column(nullable = false)
+    private String dutyName;
+
+    @Column(nullable = false)
+    private String dutyTel1;
+
+    @Column(nullable = false)
+    private int rnum;
+
+    @Column(nullable = false)
+    private double wgs84Lat;
+
+    @Column(nullable = false)
+    private double wgs84Lon;
+}

--- a/co-labor/src/main/java/pelican/co_labor/domain/hospital/HospitalResponse.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/hospital/HospitalResponse.java
@@ -1,0 +1,52 @@
+package pelican.co_labor.domain.hospital;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class HospitalResponse {
+    private Header header;
+    private Body body;
+
+    @Getter
+    @Setter
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Getter
+    @Setter
+    public static class Body {
+        @JacksonXmlProperty(localName = "items")
+        private Items items;
+
+        private int numOfRows;
+        private int pageNo;
+        private int totalCount;
+    }
+
+    @Getter
+    @Setter
+    public static class Items {
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "item")
+        private List<Item> itemList;
+    }
+
+    @Getter
+    @Setter
+    public static class Item {
+        private String dutyAddr;
+        private String dutyName;
+        private String dutyTel1;
+        private int rnum;
+        private double wgs84Lat;
+        private double wgs84Lon;
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/repository/hospital/HospitalRepository.java
+++ b/co-labor/src/main/java/pelican/co_labor/repository/hospital/HospitalRepository.java
@@ -1,0 +1,9 @@
+package pelican.co_labor.repository.hospital;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pelican.co_labor.domain.hospital.Hospital;
+
+@Repository
+public interface HospitalRepository extends JpaRepository<Hospital, Long> {
+}

--- a/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
@@ -1,0 +1,126 @@
+package pelican.co_labor.service;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import pelican.co_labor.domain.hospital.Hospital;
+import pelican.co_labor.domain.hospital.HospitalResponse;
+import pelican.co_labor.repository.hospital.HospitalRepository;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+public class HospitalService {
+
+    @Value("${public.data.api.hospital.key.decoded}")
+    private String hospitalApiKeyDecoded;
+
+    private final HospitalRepository hospitalRepository;
+
+    @Autowired
+    public HospitalService(HospitalRepository hospitalRepository) {
+        this.hospitalRepository = hospitalRepository;
+    }
+
+    public void fetchAllHospitalData() {
+        int pageNo = 1;
+        int numOfRows = 100;  // 한 페이지당 데이터 개수
+        int totalCount = 0;  // 전체 데이터 개수
+
+        // 첫 번째 호출로 totalCount를 가져옴
+        String url = "http://apis.data.go.kr/B552657/HsptlAsembySearchService/getHsptlMdcncLcinfoInqire"
+                + "?serviceKey=" + hospitalApiKeyDecoded
+                + "&pageNo=" + pageNo
+                + "&numOfRows=" + numOfRows;
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> firstResponse = restTemplate.getForEntity(url, String.class);
+
+        if (firstResponse.getStatusCode().is2xxSuccessful() && firstResponse.getBody() != null) {
+            System.out.println("First Response Body: " + firstResponse.getBody()); // 응답 출력
+
+            XmlMapper xmlMapper = new XmlMapper();
+            try {
+                HospitalResponse hospitalResponse = xmlMapper.readValue(firstResponse.getBody(), HospitalResponse.class);
+                if (hospitalResponse != null && hospitalResponse.getBody() != null) {
+                    System.out.println("Parsed Hospital Response: " + hospitalResponse);
+                    if (hospitalResponse.getBody().getItems() != null) {
+                        List<HospitalResponse.Item> items = hospitalResponse.getBody().getItems().getItemList();
+                        saveHospitals(items);
+
+                        // 전체 데이터 개수 확인
+                        totalCount = hospitalResponse.getBody().getTotalCount();
+                    } else {
+                        System.out.println("Items are null or empty.");
+                    }
+                } else {
+                    System.out.println("Hospital Response or its body is null.");
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            throw new RuntimeException("Failed to fetch data from API");
+        }
+
+        // 나머지 페이지 데이터를 가져옴
+        for (pageNo = 2; pageNo <= (totalCount / numOfRows) + 1; pageNo++) {
+            url = "http://apis.data.go.kr/B552657/HsptlAsembySearchService/getHsptlMdcncLcinfoInqire"
+                    + "?serviceKey=" + hospitalApiKeyDecoded
+                    + "&pageNo=" + pageNo
+                    + "&numOfRows=" + numOfRows;
+
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                System.out.println("Response Body for page " + pageNo + ": " + response.getBody()); // 각 페이지 응답 출력
+
+                XmlMapper xmlMapper = new XmlMapper();
+                try {
+                    HospitalResponse hospitalResponse = xmlMapper.readValue(response.getBody(), HospitalResponse.class);
+                    if (hospitalResponse != null && hospitalResponse.getBody() != null) {
+                        if (hospitalResponse.getBody().getItems() != null) {
+                            List<HospitalResponse.Item> items = hospitalResponse.getBody().getItems().getItemList();
+                            saveHospitals(items);
+                        } else {
+                            System.out.println("Items are null or empty for page " + pageNo);
+                        }
+                    } else {
+                        System.out.println("Hospital Response or its body is null for page " + pageNo);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                throw new RuntimeException("Failed to fetch data from API for page " + pageNo);
+            }
+        }
+    }
+
+    private void saveHospitals(List<HospitalResponse.Item> items) {
+        if (items == null) {
+            System.out.println("Items list is null");
+            return;
+        }
+
+        for (HospitalResponse.Item item : items) {
+            Hospital hospital = new Hospital();
+            hospital.setDutyAddr(item.getDutyAddr());
+            hospital.setDutyName(item.getDutyName());
+            hospital.setDutyTel1(item.getDutyTel1());
+            hospital.setRnum(item.getRnum());
+            hospital.setWgs84Lat(item.getWgs84Lat());
+            hospital.setWgs84Lon(item.getWgs84Lon());
+
+            hospitalRepository.save(hospital);
+        }
+    }
+
+    public List<Hospital> getAllHospitals() {
+        return hospitalRepository.findAll();
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/service/HospitalServiceInitializer.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/HospitalServiceInitializer.java
@@ -1,0 +1,22 @@
+package pelican.co_labor.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+@Service
+public class HospitalServiceInitializer {
+
+    private final HospitalService hospitalService;
+
+    @Autowired
+    public HospitalServiceInitializer(HospitalService hospitalService) {
+        this.hospitalService = hospitalService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        hospitalService.fetchAllHospitalData();
+    }
+}


### PR DESCRIPTION
## Motivation 🤔

- 병원 데이터를 공공 API에서 가져와 데이터베이스에 저장하고, 이를 조회할 수 있는 기능을 구현하여 사용자에게 최신 병원 정보를 제공하기 위함입니다.

<br>

## Related Issues 📎

- #24 

<br>

## Key Changes 🔑

- `Hospital` 엔티티 클래스 정의: 필요한 필드(`dutyAddr`, `dutyName`, `dutyTel1`, `wgs84Lat`, `wgs84Lon`) 포함
- `HospitalRepository` 인터페이스 생성: `JpaRepository` 확장
- `HospitalService` 클래스 구현:
  - 공공 API에서 병원 데이터 가져오기
  - XML 데이터를 파싱하여 `Hospital` 객체 리스트 생성
  - 데이터를 데이터베이스에 저장
  - 모든 페이지의 데이터를 순차적으로 가져오는 로직 구현
- `HospitalController` 클래스 개발:
  - `/api/hospitals/fetch` 엔드포인트: 병원 데이터를 가져와 저장
  - `/api/hospitals/all` 엔드포인트: 저장된 모든 병원 데이터를 조회
- API 키를 `application.properties`에 추가하여 보안 강화
- XML 파싱에 대한 에러 처리 및 방어적 코딩 적용

<br>