### PR TITLE
병원 데이터 추가, 지원센터, 병원 데이터 로드 방식 변경, 엔티티 변경, 기업 리스트 로드 구현

### DIFF
--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -36,6 +36,17 @@ dependencies {
 	//implementation 'org.apache.commons:commons-fileupload:1.4'
 	implementation 'org.json:json:20230618'
 
+
+	// Hugging Face Transformers 의존성
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	//implementation 'org.slf4j:slf4j-api:1.7.30'
+	implementation 'org.json:json:20210307'
+
+	//@PostConstruct 애노테이션을 사용
+	implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -45,6 +56,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 }
+
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 }
 
 
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.deeplearning4j:deeplearning4j-nlp:1.0.0-beta7'
 	implementation 'org.nd4j:nd4j-native-platform:1.0.0-beta7'
+
+	//테이블 초기화 관련 JDBC 사용
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	//implementation 'org.json:json:20210307'
 
 	implementation 'com.opencsv:opencsv:5.5.2'

--- a/co-labor/build.gradle
+++ b/co-labor/build.gradle
@@ -45,8 +45,6 @@ dependencies {
 	//@PostConstruct 애노테이션을 사용
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
-
-
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -56,7 +54,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 }
-
 
 
 tasks.named('test') {

--- a/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
+++ b/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
@@ -40,20 +40,26 @@ public class DataLoader {
         Enterprise enterprise1 = new Enterprise();
         enterprise1.setEnterprise_id("1234");
         enterprise1.setName("Tech Company");
-        enterprise1.setAddress("123 Tech Street");
+        enterprise1.setAddress1("서울특별시");
+        enterprise1.setAddress2("강동구");
         enterprise1.setDescription("Leading tech company in the industry.");
+        enterprise1.setType("유통");
+        enterprise1.setPhone_number("1234-1234");
         enterpriseRepository.save(enterprise1);
 
         Enterprise enterprise2 = new Enterprise();
         enterprise2.setEnterprise_id("5678");
         enterprise2.setName("Data Corp");
-        enterprise2.setAddress("456 Data Avenue");
+        enterprise2.setAddress1("대구광역시");
+        enterprise2.setAddress2("달서구");
         enterprise2.setDescription("Innovative data solutions provider.");
+        enterprise2.setType("건설");
+        enterprise2.setPhone_number("5678-5678");
         enterpriseRepository.save(enterprise2);
 
         // EnterpriseUser 더미 데이터 생성
         EnterpriseUser enterpriseUser1 = new EnterpriseUser();
-        enterpriseUser1.setEnterprise_user_id(1L);
+        enterpriseUser1.setEnterprise_user_id("John Doe");
         enterpriseUser1.setName("John Doe");
         enterpriseUser1.setEmail("john.doe@techcompany.com");
         enterpriseUser1.setPassword("password123");
@@ -61,7 +67,7 @@ public class DataLoader {
         enterpriseUserRepository.save(enterpriseUser1);
 
         EnterpriseUser enterpriseUser2 = new EnterpriseUser();
-        enterpriseUser2.setEnterprise_user_id(2L);
+        enterpriseUser2.setEnterprise_user_id("Jane Smith");
         enterpriseUser2.setName("Jane Smith");
         enterpriseUser2.setEmail("jane.smith@datacorp.com");
         enterpriseUser2.setPassword("password123");
@@ -70,14 +76,14 @@ public class DataLoader {
 
         // LaborUser 더미 데이터 생성
         LaborUser laborUser1 = new LaborUser();
-        laborUser1.setLabor_user_id(1L);
+        laborUser1.setLabor_user_id("Alice Johnson");
         laborUser1.setName("Alice Johnson");
         laborUser1.setEmail("alice.johnson@example.com");
         laborUser1.setPassword("password123");
         laborUserRepository.save(laborUser1);
 
         LaborUser laborUser2 = new LaborUser();
-        laborUser2.setLabor_user_id(2L);
+        laborUser2.setLabor_user_id("Bob Brown");
         laborUser2.setName("Bob Brown");
         laborUser2.setEmail("bob.brown@example.com");
         laborUser2.setPassword("password123");
@@ -87,27 +93,21 @@ public class DataLoader {
         Job job1 = new Job();
         job1.setTitle("Tech Engineer");
         job1.setDescription("Develop and maintain software solutions.");
-        job1.setGender("Any");
-        job1.setAge("Any");
         job1.setViews(100);
         job1.setDead_date(LocalDateTime.now().plusDays(30));
-        job1.setCreated_at(LocalDateTime.now());
-        job1.setModified_at(LocalDateTime.now());
         job1.setEnterprise(enterprise1);
         job1.setEnterpriseUser(enterpriseUser1);
+        job1.setRequirement("");
         jobRepository.save(job1);
 
         Job job2 = new Job();
         job2.setTitle("Data Scientist");
         job2.setDescription("Analyze and interpret complex data sets.");
-        job2.setGender("Any");
-        job2.setAge("Any");
         job2.setViews(150);
         job2.setDead_date(LocalDateTime.now().plusDays(45));
-        job2.setCreated_at(LocalDateTime.now());
-        job2.setModified_at(LocalDateTime.now());
         job2.setEnterprise(enterprise2);
         job2.setEnterpriseUser(enterpriseUser2);
+        job2.setRequirement("");
         jobRepository.save(job2);
 
         // Review 더미 데이터 생성
@@ -122,8 +122,6 @@ public class DataLoader {
         review1.setPros("Great work-life balance and culture.");
         review1.setCons("Salary could be higher.");
         review1.setLike_count(10);
-        review1.setCreated_at(LocalDateTime.now());
-        review1.setModified_at(LocalDateTime.now());
         review1.setEnterprise(enterprise1);
         review1.setLaborUser(laborUser1);
         reviewRepository.save(review1);
@@ -139,8 +137,6 @@ public class DataLoader {
         review2.setPros("Great learning opportunities.");
         review2.setCons("Work-life balance can be challenging.");
         review2.setLike_count(8);
-        review2.setCreated_at(LocalDateTime.now());
-        review2.setModified_at(LocalDateTime.now());
         review2.setEnterprise(enterprise2);
         review2.setLaborUser(laborUser2);
         reviewRepository.save(review2);

--- a/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
+++ b/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
@@ -38,14 +38,14 @@ public class DataLoader {
     public void loadData() {
         // Enterprise 더미 데이터 생성
         Enterprise enterprise1 = new Enterprise();
-        enterprise1.setEnterprise_id(1L);
+        enterprise1.setEnterprise_id("1234");
         enterprise1.setName("Tech Company");
         enterprise1.setAddress("123 Tech Street");
         enterprise1.setDescription("Leading tech company in the industry.");
         enterpriseRepository.save(enterprise1);
 
         Enterprise enterprise2 = new Enterprise();
-        enterprise2.setEnterprise_id(2L);
+        enterprise2.setEnterprise_id("5678");
         enterprise2.setName("Data Corp");
         enterprise2.setAddress("456 Data Avenue");
         enterprise2.setDescription("Innovative data solutions provider.");

--- a/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
+++ b/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
@@ -42,6 +42,7 @@ public class DataLoader {
         enterprise1.setName("Tech Company");
         enterprise1.setAddress1("서울특별시");
         enterprise1.setAddress2("강동구");
+        enterprise1.setAddress3("무슨동");
         enterprise1.setDescription("Leading tech company in the industry.");
         enterprise1.setType("유통");
         enterprise1.setPhone_number("1234-1234");
@@ -52,6 +53,7 @@ public class DataLoader {
         enterprise2.setName("Data Corp");
         enterprise2.setAddress1("대구광역시");
         enterprise2.setAddress2("달서구");
+        enterprise2.setAddress3("진천동");
         enterprise2.setDescription("Innovative data solutions provider.");
         enterprise2.setType("건설");
         enterprise2.setPhone_number("5678-5678");

--- a/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
+++ b/co-labor/src/main/java/pelican/co_labor/config/test/DataLoader.java
@@ -85,7 +85,6 @@ public class DataLoader {
 
         // Job 더미 데이터 생성
         Job job1 = new Job();
-        job1.setJob_id(1L);
         job1.setTitle("Tech Engineer");
         job1.setDescription("Develop and maintain software solutions.");
         job1.setGender("Any");
@@ -99,7 +98,6 @@ public class DataLoader {
         jobRepository.save(job1);
 
         Job job2 = new Job();
-        job2.setJob_id(2L);
         job2.setTitle("Data Scientist");
         job2.setDescription("Analyze and interpret complex data sets.");
         job2.setGender("Any");
@@ -114,7 +112,6 @@ public class DataLoader {
 
         // Review 더미 데이터 생성
         Review review1 = new Review();
-        review1.setReview_id(1L);
         review1.setTitle("Tech Place to Work");
         review1.setRating(5);
         review1.setPromotion_rating(4);
@@ -132,7 +129,6 @@ public class DataLoader {
         reviewRepository.save(review1);
 
         Review review2 = new Review();
-        review2.setReview_id(2L);
         review2.setTitle("Challenging Environment");
         review2.setRating(4);
         review2.setPromotion_rating(3);

--- a/co-labor/src/main/java/pelican/co_labor/controller/AISearchController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/AISearchController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 import pelican.co_labor.domain.enterprise.Enterprise;
 import pelican.co_labor.domain.job.Job;
 import pelican.co_labor.domain.review.Review;
-import pelican.co_labor.service.KeywordSearchService;
-import pelican.co_labor.service.OpenAiService;
-import pelican.co_labor.service.SearchService;
+import pelican.co_labor.service.Search.KeywordSearchService;
+import pelican.co_labor.service.Search.OpenAiService;
+import pelican.co_labor.service.Search.SearchService;
 
 import java.util.HashMap;
 import java.util.List;

--- a/co-labor/src/main/java/pelican/co_labor/controller/EnterpriseController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/EnterpriseController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pelican.co_labor.domain.enterprise.Enterprise;
+import pelican.co_labor.service.EnterpriseFetchApiService;
 import pelican.co_labor.service.EnterpriseService;
 
 import java.util.List;
@@ -14,10 +15,12 @@ import java.util.Optional;
 public class EnterpriseController {
 
     private final EnterpriseService enterpriseService;
+    private final EnterpriseFetchApiService enterpriseFetchApiService;
 
     @Autowired
-    public EnterpriseController(EnterpriseService enterpriseService) {
+    public EnterpriseController(EnterpriseService enterpriseService, EnterpriseFetchApiService enterpriseFetchApiService) {
         this.enterpriseService = enterpriseService;
+        this.enterpriseFetchApiService = enterpriseFetchApiService;
     }
 
     @GetMapping
@@ -31,6 +34,21 @@ public class EnterpriseController {
         return enterprise.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/fetch")
+    public String fetchAndSaveEnterpriseData() {
+        try {
+            enterpriseFetchApiService.fetchAndSaveEnterpriseData();
+            return "Data fetched and saved successfully.";
+        } catch (Exception e) {
+            return "An error occurred while fetching and saving data: " + e.getMessage();
+        }
+    }
+
+    /**
+     * 기업 등록, 수정 코드는 보완 필요
+     * @param enterprise
+     * @return
+     */
     @PostMapping
     public Enterprise createEnterprise(@RequestBody Enterprise enterprise) {
         return enterpriseService.createEnterprise(enterprise);
@@ -41,5 +59,6 @@ public class EnterpriseController {
         Optional<Enterprise> updatedEnterprise = enterpriseService.updateEnterprise(enterprise_id, enterpriseDetails);
         return updatedEnterprise.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
+
 
 }

--- a/co-labor/src/main/java/pelican/co_labor/controller/EnterpriseController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/EnterpriseController.java
@@ -1,0 +1,45 @@
+package pelican.co_labor.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pelican.co_labor.domain.enterprise.Enterprise;
+import pelican.co_labor.service.EnterpriseService;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/enterprises")
+public class EnterpriseController {
+
+    private final EnterpriseService enterpriseService;
+
+    @Autowired
+    public EnterpriseController(EnterpriseService enterpriseService) {
+        this.enterpriseService = enterpriseService;
+    }
+
+    @GetMapping
+    public List<Enterprise> getAllEnterprises() {
+        return enterpriseService.getAllEnterprises();
+    }
+
+    @GetMapping("/{enterprise_id}")
+    public ResponseEntity<Enterprise> getEnterpriseById(@PathVariable Long enterprise_id) {
+        Optional<Enterprise> enterprise = enterpriseService.getEnterpriseById(enterprise_id);
+        return enterprise.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Enterprise createEnterprise(@RequestBody Enterprise enterprise) {
+        return enterpriseService.createEnterprise(enterprise);
+    }
+
+    @PutMapping("/{enterprise_id}")
+    public ResponseEntity<Enterprise> updateEnterprise(@PathVariable Long enterprise_id, @RequestBody Enterprise enterpriseDetails) {
+        Optional<Enterprise> updatedEnterprise = enterpriseService.updateEnterprise(enterprise_id, enterpriseDetails);
+        return updatedEnterprise.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+}

--- a/co-labor/src/main/java/pelican/co_labor/controller/HospitalController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/HospitalController.java
@@ -1,0 +1,30 @@
+package pelican.co_labor.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import pelican.co_labor.domain.hospital.Hospital;
+import pelican.co_labor.service.HospitalService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hospitals")
+public class HospitalController {
+
+    private final HospitalService hospitalService;
+
+    @Autowired
+    public HospitalController(HospitalService hospitalService) {
+        this.hospitalService = hospitalService;
+    }
+
+    @GetMapping("/fetch")
+    public void fetchHospitalData() {
+        hospitalService.fetchAndSaveHospitalData();
+    }
+
+    @GetMapping("/all")
+    public List<Hospital> getAllHospitals() {
+        return hospitalService.getAllHospitals();
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/controller/SearchController.java
+++ b/co-labor/src/main/java/pelican/co_labor/controller/SearchController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import pelican.co_labor.domain.enterprise.Enterprise;
 import pelican.co_labor.domain.job.Job;
 import pelican.co_labor.domain.review.Review;
-import pelican.co_labor.service.SearchService;
+import pelican.co_labor.service.Search.SearchService;
 
 import java.util.HashMap;
 import java.util.List;

--- a/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
@@ -20,7 +20,16 @@ public class Enterprise {
     private String name;
 
     @Column(nullable = false)
-    private String address;
+    private String address1;
+
+    @Column(nullable = false)
+    private String address2;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String phone_number;
 
     @Column(columnDefinition = "TEXT")
     private String description;

--- a/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class Enterprise {
 
     @Id
+    @Column(unique = true)
     //사업자 등록 번호
     private String enterprise_id;
 
@@ -24,6 +25,9 @@ public class Enterprise {
 
     @Column(nullable = false)
     private String address2;
+
+    @Column(nullable = true)
+    private String address3;
 
     @Column(nullable = false)
     private String type;

--- a/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/enterprise/Enterprise.java
@@ -14,7 +14,7 @@ public class Enterprise {
 
     @Id
     //사업자 등록 번호
-    private Long enterprise_id;
+    private String enterprise_id;
 
     @Column(nullable = false)
     private String name;

--- a/co-labor/src/main/java/pelican/co_labor/domain/enterprise_user/EnterpriseUser.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/enterprise_user/EnterpriseUser.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "enterprise_user", uniqueConstraints = @UniqueConstraint(columnNames = "email"))
 public class EnterpriseUser {
     @Id
-    private Long enterprise_user_id;
+    private String enterprise_user_id;
 
     @Column(nullable = false)
     private String password;

--- a/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
@@ -1,0 +1,31 @@
+package pelican.co_labor.domain.hospital;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "hospital")
+public class Hospital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String dutyAddr;
+
+    @Column(nullable = false)
+    private String dutyName;
+
+    @Column(nullable = false)
+    private String dutyTel1;
+
+    @Column(nullable = false)
+    private double wgs84Lat;
+
+    @Column(nullable = false)
+    private double wgs84Lon;
+}

--- a/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/hospital/Hospital.java
@@ -11,8 +11,8 @@ import lombok.Setter;
 public class Hospital {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(nullable = false)
+    private Long rnum;
 
     @Column(nullable = false)
     private String dutyAddr;

--- a/co-labor/src/main/java/pelican/co_labor/domain/job/Job.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/job/Job.java
@@ -32,11 +32,8 @@ public class Job {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column
-    private String gender;
-
-    @Column
-    private String age;
+    @Column(columnDefinition = "TEXT")
+    private String requirement;
 
     @Column(nullable = false)
     private int views;

--- a/co-labor/src/main/java/pelican/co_labor/domain/labor_user/LaborUser.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/labor_user/LaborUser.java
@@ -13,8 +13,7 @@ import java.time.LocalDateTime;
 public class LaborUser {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long labor_user_id;
+    private String labor_user_id;
 
     @Column(nullable = false)
     private String password;

--- a/co-labor/src/main/java/pelican/co_labor/domain/review/Review.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/review/Review.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class Review {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long review_id;
 
     @ManyToOne

--- a/co-labor/src/main/java/pelican/co_labor/domain/support_center/SupportCenter.java
+++ b/co-labor/src/main/java/pelican/co_labor/domain/support_center/SupportCenter.java
@@ -13,8 +13,7 @@ import java.time.LocalDateTime;
 public class SupportCenter {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long support_center_id;
+    private Long support_center_id; // "순번"을 primary key로 사용
 
     @Column(nullable = false)
     private String name;

--- a/co-labor/src/main/java/pelican/co_labor/repository/enterprise/EnterpriseRepository.java
+++ b/co-labor/src/main/java/pelican/co_labor/repository/enterprise/EnterpriseRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Repository
 public interface EnterpriseRepository extends JpaRepository<Enterprise, Long> {
 
-    @Query("SELECT e FROM Enterprise e WHERE LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address1) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address2) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.type) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    @Query("SELECT e FROM Enterprise e WHERE LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address1) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address2) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address3) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.type) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     List<Enterprise> searchEnterprises(@Param("keyword") String keyword);
 }

--- a/co-labor/src/main/java/pelican/co_labor/repository/enterprise/EnterpriseRepository.java
+++ b/co-labor/src/main/java/pelican/co_labor/repository/enterprise/EnterpriseRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Repository
 public interface EnterpriseRepository extends JpaRepository<Enterprise, Long> {
 
-    @Query("SELECT e FROM Enterprise e WHERE LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    @Query("SELECT e FROM Enterprise e WHERE LOWER(e.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address1) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.address2) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.type) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(e.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     List<Enterprise> searchEnterprises(@Param("keyword") String keyword);
 }

--- a/co-labor/src/main/java/pelican/co_labor/repository/hospital/HospitalRepository.java
+++ b/co-labor/src/main/java/pelican/co_labor/repository/hospital/HospitalRepository.java
@@ -1,0 +1,9 @@
+package pelican.co_labor.repository.hospital;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pelican.co_labor.domain.hospital.Hospital;
+
+@Repository
+public interface HospitalRepository extends JpaRepository<Hospital, Long> {
+}

--- a/co-labor/src/main/java/pelican/co_labor/repository/job/JobRepository.java
+++ b/co-labor/src/main/java/pelican/co_labor/repository/job/JobRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Repository
 public interface JobRepository extends JpaRepository<Job, Long> {
-    @Query("SELECT j FROM Job j WHERE LOWER(j.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(j.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    @Query("SELECT j FROM Job j WHERE LOWER(j.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(j.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(j.requirement) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     List<Job> searchJobs(@Param("keyword") String keyword);
 }
 

--- a/co-labor/src/main/java/pelican/co_labor/service/DataPreparationService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/DataPreparationService.java
@@ -51,8 +51,8 @@ public class DataPreparationService {
                     .map(Job::getTitle)
                     .collect(Collectors.toList()));
 
-            List<String> jobGenders = getSafeList(jobRepository.findAll().stream()
-                    .map(Job::getGender)
+            List<String> jobConditions = getSafeList(jobRepository.findAll().stream()
+                    .map(Job::getRequirement)
                     .collect(Collectors.toList()));
 
             logger.info("Extracting data from Review repository...");
@@ -77,13 +77,21 @@ public class DataPreparationService {
                     .map(Enterprise::getName)
                     .collect(Collectors.toList()));
 
-            List<String> enterpriseAddresses = getSafeList(enterpriseRepository.findAll().stream()
-                    .map(Enterprise::getAddress)
+            List<String> enterpriseAddresses1 = getSafeList(enterpriseRepository.findAll().stream()
+                    .map(Enterprise::getAddress1)
+                    .collect(Collectors.toList()));
+
+            List<String> enterpriseAddresses2 = getSafeList(enterpriseRepository.findAll().stream()
+                    .map(Enterprise::getAddress2)
+                    .collect(Collectors.toList()));
+
+            List<String> enterpriseTypes = getSafeList(enterpriseRepository.findAll().stream()
+                    .map(Enterprise::getType)
                     .collect(Collectors.toList()));
 
             // 모든 데이터를 하나의 리스트로 합치기
             logger.info("Combining all extracted data into a single list...");
-            List<String> sentences = Stream.of(jobDescriptions, jobTitles, jobGenders, reviewPros, reviewCons, reviewTitles, enterpriseDescriptions, enterpriseNames, enterpriseAddresses)
+            List<String> sentences = Stream.of(jobDescriptions, jobTitles, jobConditions, reviewPros, reviewCons, reviewTitles, enterpriseDescriptions, enterpriseNames, enterpriseAddresses1, enterpriseAddresses2, enterpriseTypes)
                     .flatMap(List::stream)
                     .collect(Collectors.toList());
 

--- a/co-labor/src/main/java/pelican/co_labor/service/EnterpriseFetchApiService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/EnterpriseFetchApiService.java
@@ -1,0 +1,99 @@
+package pelican.co_labor.service;
+
+import jakarta.annotation.PostConstruct;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import pelican.co_labor.domain.enterprise.Enterprise;
+import pelican.co_labor.repository.enterprise.EnterpriseRepository;
+
+import java.util.regex.Pattern;
+
+@Service
+public class EnterpriseFetchApiService {
+
+    @Value("${public.enterprise.list.key.decoded}")
+    private String serviceKey;
+
+    @Autowired
+    private final EnterpriseRepository enterpriseRepository;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public EnterpriseFetchApiService(EnterpriseRepository enterpriseRepository) {
+        this.enterpriseRepository = enterpriseRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (enterpriseRepository.count() == 0) {
+            fetchAndSaveEnterpriseData();
+        }
+    }
+
+    public void fetchAndSaveEnterpriseData() {
+        String apiUrl = "http://apis.data.go.kr/1160100/service/GetCorpBasicInfoService_V2/getCorpOutline_V2";
+        int numOfRows = 1000; // 한 번에 가져올 행 수
+        int pageNo = 1; // 시작 페이지 번호
+
+        while (true) {
+            String urlStr = apiUrl + "?serviceKey=" + serviceKey + "&numOfRows=" + numOfRows + "&pageNo=" + pageNo + "&resultType=json";
+            ResponseEntity<String> response = restTemplate.getForEntity(urlStr, String.class);
+
+            String responseBody = response.getBody();
+            if (responseBody == null || responseBody.isEmpty()) {
+                System.err.println("Empty response body for URL: " + urlStr);
+                break;
+            }
+
+            JSONObject jsonResponse;
+            try {
+                jsonResponse = new JSONObject(responseBody);
+            } catch (Exception e) {
+                System.err.println("Invalid JSON response: " + responseBody);
+                break;
+            }
+
+            JSONArray items = jsonResponse.getJSONObject("response").getJSONObject("body").getJSONObject("items").getJSONArray("item");
+
+            if (items.isEmpty() || pageNo>=15) {
+                break; // 데이터가 없으면 루프 종료
+            }
+
+            for (int i = 0; i < items.length(); i++) {
+                JSONObject item = items.getJSONObject(i);
+                if (item.isNull("corpNm")) continue;
+
+                String enpBsadr = item.getString("enpBsadr");
+                if (Pattern.matches(".*[가-힣]+.*", enpBsadr)) {
+                    String[] addressParts = enpBsadr.split(" ", 3);
+
+                    Enterprise enterprise = new Enterprise();
+                    enterprise.setEnterprise_id(item.getString("bzno"));
+                    enterprise.setName(item.getString("corpNm"));
+                    enterprise.setType(item.getString("sicNm"));
+                    enterprise.setDescription(item.getString("enpMainBizNm"));
+                    enterprise.setPhone_number(item.getString("enpTlno"));
+
+                    if (addressParts.length > 0) {
+                        enterprise.setAddress1(addressParts[0]);
+                    }
+                    if (addressParts.length > 1) {
+                        enterprise.setAddress2(addressParts[1]);
+                    }
+                    if (addressParts.length > 2) {
+                        enterprise.setAddress3(addressParts[2]);
+                    }
+
+                    enterpriseRepository.save(enterprise); // 이미 존재하면 덮어씌움
+                }
+            }
+
+            pageNo++; // 다음 페이지로 넘어감
+        }
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/service/EnterpriseService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/EnterpriseService.java
@@ -33,8 +33,11 @@ public class EnterpriseService {
     public Optional<Enterprise> updateEnterprise(Long enterpriseId, Enterprise enterpriseDetails) {
         return enterpriseRepository.findById(enterpriseId).map(enterprise -> {
             enterprise.setName(enterpriseDetails.getName());
-            enterprise.setAddress(enterpriseDetails.getAddress());
+            enterprise.setAddress1(enterpriseDetails.getAddress1());
+            enterprise.setAddress2(enterpriseDetails.getAddress2());
             enterprise.setDescription(enterpriseDetails.getDescription());
+            enterprise.setType(enterpriseDetails.getType());
+            enterprise.setPhone_number(enterpriseDetails.getPhone_number());
             return enterpriseRepository.save(enterprise);
         });
     }

--- a/co-labor/src/main/java/pelican/co_labor/service/EnterpriseService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/EnterpriseService.java
@@ -1,0 +1,42 @@
+package pelican.co_labor.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pelican.co_labor.domain.enterprise.Enterprise;
+import pelican.co_labor.repository.enterprise.EnterpriseRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class EnterpriseService {
+
+    private final EnterpriseRepository enterpriseRepository;
+
+    @Autowired
+    public EnterpriseService(EnterpriseRepository enterpriseRepository) {
+        this.enterpriseRepository = enterpriseRepository;
+    }
+
+    public List<Enterprise> getAllEnterprises() {
+        return enterpriseRepository.findAll();
+    }
+
+    public Optional<Enterprise> getEnterpriseById(Long enterpriseId) {
+        return enterpriseRepository.findById(enterpriseId);
+    }
+
+    public Enterprise createEnterprise(Enterprise enterprise) {
+        return enterpriseRepository.save(enterprise);
+    }
+
+    public Optional<Enterprise> updateEnterprise(Long enterpriseId, Enterprise enterpriseDetails) {
+        return enterpriseRepository.findById(enterpriseId).map(enterprise -> {
+            enterprise.setName(enterpriseDetails.getName());
+            enterprise.setAddress(enterpriseDetails.getAddress());
+            enterprise.setDescription(enterpriseDetails.getDescription());
+            return enterpriseRepository.save(enterprise);
+        });
+    }
+
+}

--- a/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
@@ -1,0 +1,120 @@
+package pelican.co_labor.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import pelican.co_labor.domain.hospital.Hospital;
+import pelican.co_labor.repository.hospital.HospitalRepository;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class HospitalService {
+
+    @Value("${public.data.api.key.decoded}")
+    private String serviceKey;
+
+    private final HospitalRepository hospitalRepository;
+
+    @Autowired
+    public HospitalService(HospitalRepository hospitalRepository) {
+        this.hospitalRepository = hospitalRepository;
+    }
+
+    public void fetchAndSaveHospitalData() {
+        String apiUrl = "http://apis.data.go.kr/B552657/HsptlAsembySearchService/getHsptlMdcncListInfoInqire";
+        int numOfRows = 1000; // 한 번에 가져올 행 수
+        int totalCount = getTotalCount(apiUrl); // 전체 데이터 개수
+        int totalPages = (totalCount / numOfRows) + 1; // 전체 페이지 수
+
+        try {
+            for (int pageNo = 1; pageNo <= totalPages; pageNo++) {
+                String urlStr = apiUrl + "?serviceKey=" + serviceKey + "&numOfRows=" + numOfRows + "&pageNo=" + pageNo;
+                URL url = new URL(urlStr);
+                DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+                Document doc = dBuilder.parse(url.openStream());
+
+                doc.getDocumentElement().normalize();
+
+                NodeList nList = doc.getElementsByTagName("item");
+
+                List<Hospital> hospitals = new ArrayList<>();
+
+                for (int temp = 0; temp < nList.getLength(); temp++) {
+                    Node nNode = nList.item(temp);
+
+                    if (nNode.getNodeType() == Node.ELEMENT_NODE) {
+                        Element eElement = (Element) nNode;
+
+                        Hospital hospital = new Hospital();
+                        hospital.setDutyAddr(getTagValue("dutyAddr", eElement));
+                        hospital.setDutyName(getTagValue("dutyName", eElement));
+                        hospital.setDutyTel1(getTagValue("dutyTel1", eElement));
+                        hospital.setWgs84Lat(parseDoubleOrDefault(getTagValue("wgs84Lat", eElement)));
+                        hospital.setWgs84Lon(parseDoubleOrDefault(getTagValue("wgs84Lon", eElement)));
+
+                        hospitals.add(hospital);
+                    }
+                }
+
+                hospitalRepository.saveAll(hospitals);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String getTagValue(String tag, Element eElement) {
+        NodeList nodeList = eElement.getElementsByTagName(tag);
+        if (nodeList.getLength() > 0) {
+            Node node = nodeList.item(0).getFirstChild();
+            if (node != null) {
+                return node.getNodeValue();
+            }
+        }
+        return "";
+    }
+
+    private double parseDoubleOrDefault(String value) {
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    private int getTotalCount(String apiUrl) {
+        try {
+            String urlStr = apiUrl + "?serviceKey=" + serviceKey + "&numOfRows=1&pageNo=1";
+            URL url = new URL(urlStr);
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(url.openStream());
+
+            doc.getDocumentElement().normalize();
+
+            NodeList nList = doc.getElementsByTagName("body");
+            if (nList.getLength() > 0) {
+                Element eElement = (Element) nList.item(0);
+                return Integer.parseInt(getTagValue("totalCount", eElement));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public List<Hospital> getAllHospitals() {
+        return hospitalRepository.findAll();
+    }
+}

--- a/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/HospitalService.java
@@ -2,6 +2,7 @@ package pelican.co_labor.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -23,10 +24,12 @@ public class HospitalService {
     private String serviceKey;
 
     private final HospitalRepository hospitalRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Autowired
-    public HospitalService(HospitalRepository hospitalRepository) {
+    public HospitalService(HospitalRepository hospitalRepository, JdbcTemplate jdbcTemplate) {
         this.hospitalRepository = hospitalRepository;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void fetchAndSaveHospitalData() {
@@ -36,6 +39,10 @@ public class HospitalService {
         int totalPages = (totalCount / numOfRows) + 1; // 전체 페이지 수
 
         try {
+            // 데이터 삭제 및 테이블 초기화
+            hospitalRepository.deleteAll();
+            //jdbcTemplate.execute("ALTER TABLE hospital AUTO_INCREMENT = 1");
+
             for (int pageNo = 1; pageNo <= totalPages; pageNo++) {
                 String urlStr = apiUrl + "?serviceKey=" + serviceKey + "&numOfRows=" + numOfRows + "&pageNo=" + pageNo;
                 URL url = new URL(urlStr);
@@ -56,6 +63,7 @@ public class HospitalService {
                         Element eElement = (Element) nNode;
 
                         Hospital hospital = new Hospital();
+                        hospital.setRnum(Long.parseLong(getTagValue("rnum", eElement)));
                         hospital.setDutyAddr(getTagValue("dutyAddr", eElement));
                         hospital.setDutyName(getTagValue("dutyName", eElement));
                         hospital.setDutyTel1(getTagValue("dutyTel1", eElement));

--- a/co-labor/src/main/java/pelican/co_labor/service/JobService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/JobService.java
@@ -34,8 +34,7 @@ public class JobService {
         return jobRepository.findById(jobId).map(job -> {
             job.setTitle(jobDetails.getTitle());
             job.setDescription(jobDetails.getDescription());
-            job.setGender(jobDetails.getGender());
-            job.setAge(jobDetails.getAge());
+            job.setRequirement(jobDetails.getRequirement());
             job.setViews(jobDetails.getViews());
             job.setDead_date(jobDetails.getDead_date());
             job.setModified_at(jobDetails.getModified_at());

--- a/co-labor/src/main/java/pelican/co_labor/service/Search/DataPreparationService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/Search/DataPreparationService.java
@@ -1,4 +1,4 @@
-package pelican.co_labor.service;
+package pelican.co_labor.service.Search;
 
 import jakarta.annotation.PostConstruct;
 import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
@@ -85,13 +85,17 @@ public class DataPreparationService {
                     .map(Enterprise::getAddress2)
                     .collect(Collectors.toList()));
 
+            List<String> enterpriseAddresses3 = getSafeList(enterpriseRepository.findAll().stream()
+                    .map(Enterprise::getAddress3)
+                    .collect(Collectors.toList()));
+
             List<String> enterpriseTypes = getSafeList(enterpriseRepository.findAll().stream()
                     .map(Enterprise::getType)
                     .collect(Collectors.toList()));
 
             // 모든 데이터를 하나의 리스트로 합치기
             logger.info("Combining all extracted data into a single list...");
-            List<String> sentences = Stream.of(jobDescriptions, jobTitles, jobConditions, reviewPros, reviewCons, reviewTitles, enterpriseDescriptions, enterpriseNames, enterpriseAddresses1, enterpriseAddresses2, enterpriseTypes)
+            List<String> sentences = Stream.of(jobDescriptions, jobTitles, jobConditions, reviewPros, reviewCons, reviewTitles, enterpriseDescriptions, enterpriseNames, enterpriseAddresses1, enterpriseAddresses2, enterpriseAddresses3 , enterpriseTypes)
                     .flatMap(List::stream)
                     .collect(Collectors.toList());
 

--- a/co-labor/src/main/java/pelican/co_labor/service/Search/KeywordSearchService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/Search/KeywordSearchService.java
@@ -1,4 +1,4 @@
-package pelican.co_labor.service;
+package pelican.co_labor.service.Search;
 
 import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
 import org.deeplearning4j.models.word2vec.Word2Vec;

--- a/co-labor/src/main/java/pelican/co_labor/service/Search/OpenAiService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/Search/OpenAiService.java
@@ -1,4 +1,4 @@
-package pelican.co_labor.service;
+package pelican.co_labor.service.Search;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/co-labor/src/main/java/pelican/co_labor/service/Search/SearchService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/Search/SearchService.java
@@ -1,4 +1,4 @@
-package pelican.co_labor.service;
+package pelican.co_labor.service.Search;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,14 +15,17 @@ import java.util.stream.Collectors;
 @Service
 public class SearchService {
 
-    @Autowired
-    private JobRepository jobRepository;
+    private final JobRepository jobRepository;
 
-    @Autowired
-    private ReviewRepository reviewRepository;
+    private final ReviewRepository reviewRepository;
 
-    @Autowired
-    private EnterpriseRepository enterpriseRepository;
+    private final EnterpriseRepository enterpriseRepository;
+
+    public SearchService(JobRepository jobRepository, ReviewRepository reviewRepository, EnterpriseRepository enterpriseRepository) {
+        this.jobRepository = jobRepository;
+        this.reviewRepository = reviewRepository;
+        this.enterpriseRepository = enterpriseRepository;
+    }
 
     public List<Job> searchJobs(String keyword) {
         return jobRepository.searchJobs(keyword);

--- a/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
@@ -60,14 +60,15 @@ public class SupportCenterService {
         ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
 
         if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            List<Map<String, String>> records = (List<Map<String, String>>) response.getBody().get("data");
+            List<Map<String, Object>> records = (List<Map<String, Object>>) response.getBody().get("data");
 
-            for (Map<String, String> record : records) {
+            for (Map<String, Object> record : records) {
                 SupportCenter supportCenter = new SupportCenter();
-                supportCenter.setCenter_type(record.get("유형"));
-                supportCenter.setName(record.get("기관명(거점센터 운영기관)"));
-                supportCenter.setAddress(record.get("소재지"));
-                supportCenter.setPhone(record.get("연락처"));
+                supportCenter.setSupport_center_id(Long.valueOf(record.get("순번").toString()));
+                supportCenter.setCenter_type(record.get("유형").toString());
+                supportCenter.setName(record.get("기관명(거점센터 운영기관)").toString());
+                supportCenter.setAddress(record.get("소재지").toString());
+                supportCenter.setPhone(record.get("연락처").toString());
 
                 // 네이버 지오코딩 서비스 사용하여 위도와 경도 설정
                 String coordinates = naverGeocodingService.getCoordinates(supportCenter.getAddress());

--- a/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
+++ b/co-labor/src/main/java/pelican/co_labor/service/SupportCenterService.java
@@ -8,6 +8,7 @@ import org.springframework.web.client.RestTemplate;
 import pelican.co_labor.domain.support_center.SupportCenter;
 import pelican.co_labor.repository.support_center.SupportCenterRepository;
 
+import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +30,14 @@ public class SupportCenterService {
         this.naverGeocodingService = naverGeocodingService;
     }
 
+    @PostConstruct
+    public void init() {
+        fetchDataFromApi();
+    }
+
     public void fetchDataFromApi() {
+        supportCenterRepository.deleteAll(); // 기존 데이터 삭제
+
         // 인코딩된 키로 데이터 가져오기 시도
         try {
             fetchDataUsingKey(apiKeyEncoded);

--- a/co-labor/src/test/java/pelican/co_labor/controller/SearchControllerTest.java
+++ b/co-labor/src/test/java/pelican/co_labor/controller/SearchControllerTest.java
@@ -11,7 +11,7 @@ import pelican.co_labor.domain.review.Review;
 import pelican.co_labor.repository.enterprise.EnterpriseRepository;
 import pelican.co_labor.repository.job.JobRepository;
 import pelican.co_labor.repository.review.ReviewRepository;
-import pelican.co_labor.service.SearchService;
+import pelican.co_labor.service.Search.SearchService;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
## Related Issues 📎

- #23 #24 #25 #26 

<br>

## Key Changes 🔑

1. 공공데이터에서 불러올 수 있는 약 76000개의 병원 데이터를 DB에 저장하는 API.
2. DB에 저장한 데이터를 조회하는 API

- ### 엔티티 수정

기업 엔티티

- 추가 : address1(시/도), address2(구/군), address3(기타 주소), type(기업 분류), phone_number
- 유지 : name, description, address
- 수정 : enterprise_id(사업자 번호, string)
- 삭제 : address

채용공고 엔티티

- 삭제 : age, gender
- 유지 : job_id, created_at, dead_date, modified_at, views, description, title, EnterpriseUser, Enterprise
- 추가 : requirement : (string) (예시 4년제 대학 이상, 경력 2년 이상, js, java 사용 경험 등)

EnterpriseUser 엔티티

- 수정 : enterprise_user_id(Long → String)

LaborUser 엔티티

- 수정 : labor_user_id(Long → String, Not Generated)

엔티티 수정에 따른 DataPreparationService 및 관련된 클래스 수정

### 기업 데이터 받아오기

- https://www.data.go.kr/data/15043184/openapi.do#/


